### PR TITLE
User group metadata role

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRole.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRole.java
@@ -52,6 +52,13 @@ public enum ProjectMetadataRole {
 		return level;
 	}
 
+	/**
+	 * Static method to compare a {@link ProjectUserJoin} and a collection of {@link UserGroupProjectJoin} and return the max {@link ProjectMetadataRole} from them
+	 *
+	 * @param userJoin   a user's {@link ProjectUserJoin}
+	 * @param groupJoins a collection of {@link UserGroupProjectJoin}
+	 * @return the max {@link ProjectMetadataRole}
+	 */
 	public static ProjectMetadataRole getMaxRoleForProjectAndGroups(ProjectUserJoin userJoin,
 			Collection<UserGroupProjectJoin> groupJoins) {
 		ProjectMetadataRole metadataRole = null;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRole.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRole.java
@@ -1,5 +1,10 @@
 package ca.corefacility.bioinformatics.irida.model.enums;
 
+import java.util.Collection;
+
+import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectUserJoin;
+import ca.corefacility.bioinformatics.irida.model.user.group.UserGroupProjectJoin;
+
 /**
  * Role for a user's level of metadata access for a project.
  */
@@ -45,5 +50,23 @@ public enum ProjectMetadataRole {
 
 	public int getLevel() {
 		return level;
+	}
+
+	public static ProjectMetadataRole getMaxRoleForProjectAndGroups(ProjectUserJoin userJoin,
+			Collection<UserGroupProjectJoin> groupJoins) {
+		ProjectMetadataRole metadataRole = null;
+
+		if (userJoin != null) {
+			metadataRole = userJoin.getMetadataRole();
+		}
+
+		for (UserGroupProjectJoin group : groupJoins) {
+			if (metadataRole.getLevel() < group.getMetadataRole()
+					.getLevel()) {
+				metadataRole = group.getMetadataRole();
+			}
+		}
+
+		return metadataRole;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/user/group/UserGroupProjectJoin.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/user/group/UserGroupProjectJoin.java
@@ -25,6 +25,7 @@ import org.hibernate.envers.Audited;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import ca.corefacility.bioinformatics.irida.model.enums.ProjectMetadataRole;
 import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.model.joins.Join;
 import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectUserJoin;
@@ -62,6 +63,11 @@ public class UserGroupProjectJoin implements Join<Project, UserGroup> {
 	private ProjectRole projectRole;
 
 	@NotNull
+	@Enumerated(EnumType.STRING)
+	@Column(name = "metadata_role")
+	private ProjectMetadataRole metadataRole;
+
+	@NotNull
 	@CreatedDate
 	@Temporal(TemporalType.TIMESTAMP)
 	@Column(name = "created_date", updatable = false)
@@ -88,12 +94,13 @@ public class UserGroupProjectJoin implements Join<Project, UserGroup> {
 	 *                  {@link Project}.
 	 * @param role      The Role the users in the group should have
 	 */
-	public UserGroupProjectJoin(final Project project, final UserGroup userGroup, final ProjectRole role) {
+	public UserGroupProjectJoin(final Project project, final UserGroup userGroup, final ProjectRole role, final ProjectMetadataRole metadataRole) {
 		this.id = null;
 		this.createdDate = new Date();
 		this.project = project;
 		this.userGroup = userGroup;
 		this.projectRole = role;
+		this.metadataRole = metadataRole;
 	}
 
 	@Override
@@ -146,6 +153,14 @@ public class UserGroupProjectJoin implements Join<Project, UserGroup> {
 	@Override
 	public Date getTimestamp() {
 		return this.createdDate;
+	}
+
+	public ProjectMetadataRole getMetadataRole() {
+		return metadataRole;
+	}
+
+	public void setMetadataRole(ProjectMetadataRole metadataRole) {
+		this.metadataRole = metadataRole;
 	}
 
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/user/group/UserGroupProjectJoin.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/user/group/UserGroupProjectJoin.java
@@ -88,11 +88,12 @@ public class UserGroupProjectJoin implements Join<Project, UserGroup> {
 	/**
 	 * Create a new {@link UserGroupProjectJoin}.
 	 *
-	 * @param project   the {@link Project} that you're permitting the
-	 *                  {@link UserGroup} to access.
-	 * @param userGroup the {@link UserGroup} being permitted to access the
-	 *                  {@link Project}.
-	 * @param role      The Role the users in the group should have
+	 * @param project      the {@link Project} that you're permitting the
+	 *                     {@link UserGroup} to access.
+	 * @param userGroup    the {@link UserGroup} being permitted to access the
+	 *                     {@link Project}.
+	 * @param role         The Role the users in the group should have
+	 * @param metadataRole the {@link ProjectMetadataRole} users in the group should have
 	 */
 	public UserGroupProjectJoin(final Project project, final UserGroup userGroup, final ProjectRole role, final ProjectMetadataRole metadataRole) {
 		this.id = null;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/joins/project/UserGroupProjectJoinRepository.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/joins/project/UserGroupProjectJoinRepository.java
@@ -67,6 +67,13 @@ public interface UserGroupProjectJoinRepository extends IridaJpaRepository<UserG
 	 */
 	public UserGroupProjectJoin findByProjectAndUserGroup(final Project p, final UserGroup userGroup);
 
+	/**
+	 * Get the {@link UserGroupProjectJoin} (potentially more than 1) between a given {@link User} and {@link Project}
+	 *
+	 * @param project the {@link Project} to get joins for
+	 * @param user    the {@link User} to get joins for
+	 * @return a list of {@link UserGroupProjectJoin}
+	 */
 	@Query("FROM UserGroupProjectJoin ugpj WHERE ugpj.project = ?1 AND ugpj.userGroup in (select group from UserGroupJoin where user = ?2)")
 	public List<UserGroupProjectJoin> findGroupsForProjectAndUser(Project project, User user);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/joins/project/UserGroupProjectJoinRepository.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/joins/project/UserGroupProjectJoinRepository.java
@@ -1,6 +1,7 @@
 package ca.corefacility.bioinformatics.irida.repositories.joins.project;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.Query;
 
@@ -18,7 +19,7 @@ public interface UserGroupProjectJoinRepository extends IridaJpaRepository<UserG
 
 	/**
 	 * Find all groups with access to the project.
-	 * 
+	 *
 	 * @param p
 	 *            the project to check
 	 * @return the groups assigned to the project.
@@ -32,10 +33,10 @@ public interface UserGroupProjectJoinRepository extends IridaJpaRepository<UserG
 	 * @return the projects linked to the user group.
 	 */
 	public Collection<UserGroupProjectJoin> findProjectsByUserGroup(final UserGroup ug);
-	
+
 	/**
 	 * Find all groups with access to the project with a specific role.
-	 * 
+	 *
 	 * @param p
 	 *            the project
 	 * @param projectRole
@@ -47,7 +48,7 @@ public interface UserGroupProjectJoinRepository extends IridaJpaRepository<UserG
 
 	/**
 	 * Find the projects where the specified user is in a group on the project.
-	 * 
+	 *
 	 * @param u
 	 *            the user.
 	 * @return the projects that the user is in via a group.
@@ -57,7 +58,7 @@ public interface UserGroupProjectJoinRepository extends IridaJpaRepository<UserG
 
 	/**
 	 * Find the join for a user group and project.
-	 * 
+	 *
 	 * @param p
 	 *            the project
 	 * @param userGroup
@@ -65,4 +66,7 @@ public interface UserGroupProjectJoinRepository extends IridaJpaRepository<UserG
 	 * @return the relationship between the group and project.
 	 */
 	public UserGroupProjectJoin findByProjectAndUserGroup(final Project p, final UserGroup userGroup);
+
+	@Query("FROM UserGroupProjectJoin ugpj WHERE ugpj.project = ?1 AND ugpj.userGroup in (select group from UserGroupJoin where user = ?2)")
+	public List<UserGroupProjectJoin> findGroupsForProjectAndUser(Project project, User user);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/ajax/projects/ProjectUserGroupsAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/ajax/projects/ProjectUserGroupsAjaxController.java
@@ -86,10 +86,11 @@ public class ProjectUserGroupsAjaxController {
 	/**
 	 * Update the project role of a user group on the current project
 	 *
-	 * @param projectId Identifier for a project
-	 * @param id        Identifier for an user group
-	 * @param role      Role to update the user group to
-	 * @param locale    Current users locale
+	 * @param projectId    Identifier for a project
+	 * @param id           Identifier for an user group
+	 * @param role         Role to update the user group to
+	 * @param metadataRole metadata role to update for the user group
+	 * @param locale       Current users locale
 	 * @return message to user about the result of the update
 	 */
 	@RequestMapping(value = "/role", method = RequestMethod.PUT)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/ajax/projects/ProjectUserGroupsAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/ajax/projects/ProjectUserGroupsAjaxController.java
@@ -94,9 +94,9 @@ public class ProjectUserGroupsAjaxController {
 	 */
 	@RequestMapping(value = "/role", method = RequestMethod.PUT)
 	public ResponseEntity<String> updateUserGroupRoleOnProject(@RequestParam Long projectId, @RequestParam Long id,
-			@RequestParam String role, Locale locale) {
+			@RequestParam String role, @RequestParam String metadataRole, Locale locale) {
 		try {
-			return ResponseEntity.ok(service.updateUserGroupRoleOnProject(projectId, id, role, locale));
+			return ResponseEntity.ok(service.updateUserGroupRoleOnProject(projectId, id, role, metadataRole, locale));
 		} catch (ProjectWithoutOwnerException e) {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 					.body(e.getMessage());

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectUserGroupsService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectUserGroupsService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import ca.corefacility.bioinformatics.irida.exceptions.ProjectWithoutOwnerException;
+import ca.corefacility.bioinformatics.irida.model.enums.ProjectMetadataRole;
 import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.user.group.UserGroup;
@@ -100,7 +101,8 @@ public class UIProjectUserGroupsService {
 		Project project = projectService.read(projectId);
 		UserGroup group = userGroupService.read(request.getId());
 		ProjectRole role = ProjectRole.fromString(request.getRole());
-		projectService.addUserGroupToProject(project, group, role);
+		ProjectMetadataRole metadataRole = ProjectMetadataRole.fromString(request.getMetadataRole());
+		projectService.addUserGroupToProject(project, group, role, metadataRole);
 		return messageSource.getMessage("server.usergroups.add", new Object[] { group.getLabel() }, locale);
 	}
 
@@ -114,15 +116,17 @@ public class UIProjectUserGroupsService {
 	 * @return message to user about the result of the update
 	 * @throws ProjectWithoutOwnerException thrown when updating the role will result in the project to have no owner
 	 */
-	public String updateUserGroupRoleOnProject(Long projectId, Long groupId, String role, Locale locale)
+	public String updateUserGroupRoleOnProject(Long projectId, Long groupId, String role, String metadataRole, Locale locale)
 			throws ProjectWithoutOwnerException {
 		Project project = projectService.read(projectId);
 		UserGroup group = userGroupService.read(groupId);
 		ProjectRole projectRole = ProjectRole.fromString(role);
+		ProjectMetadataRole projectMetadataRole = ProjectMetadataRole.fromString(metadataRole);
+
 		String roleString = messageSource.getMessage("projectRole." + role, new Object[] {}, locale);
 
 		try {
-			projectService.updateUserGroupProjectRole(project, group, projectRole);
+			projectService.updateUserGroupProjectRole(project, group, projectRole, projectMetadataRole);
 			return messageSource.getMessage("server.usergroups.update.success",
 					new Object[] { group.getLabel(), roleString }, locale);
 		} catch (ProjectWithoutOwnerException e) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectUserGroupsService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectUserGroupsService.java
@@ -109,10 +109,11 @@ public class UIProjectUserGroupsService {
 	/**
 	 * Update the {@link ProjectRole} of a {@link UserGroup} on the current {@link Project}
 	 *
-	 * @param projectId Identifier for a {@link Project}
-	 * @param groupId   Identifier for an {@link UserGroup}
-	 * @param role      Role to update the user group to
-	 * @param locale    Current users {@link Locale}
+	 * @param projectId    Identifier for a {@link Project}
+	 * @param groupId      Identifier for an {@link UserGroup}
+	 * @param role         Role to update the user group to
+	 * @param metadataRole metadata role to update for the group
+	 * @param locale       Current users {@link Locale}
 	 * @return message to user about the result of the update
 	 * @throws ProjectWithoutOwnerException thrown when updating the role will result in the project to have no owner
 	 */

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadMetadataEntryPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadMetadataEntryPermission.java
@@ -96,22 +96,5 @@ public class ReadMetadataEntryPermission extends RepositoryBackedPermission<Meta
 
 		return false;
 	}
-
-	private ProjectMetadataRole getMaxMetadataRoleForUserAndGroups(ProjectUserJoin userJoin,
-			List<UserGroupProjectJoin> groupsForProjectAndUser) {
-		ProjectMetadataRole metadataRole = null;
-
-		if (userJoin != null) {
-			metadataRole = userJoin.getMetadataRole();
-		}
-
-		for (UserGroupProjectJoin group : groupsForProjectAndUser) {
-			if (metadataRole.getLevel() < group.getMetadataRole()
-					.getLevel()) {
-				metadataRole = group.getMetadataRole();
-			}
-		}
-
-		return metadataRole;
-	}
+	
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadProjectMetadataResponsePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadProjectMetadataResponsePermission.java
@@ -27,7 +27,8 @@ import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
 import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
 
 /**
- * Permission for checking that a user should have access to the given {@link MetadataTemplateField}s in a {@link ProjectMetadataResponse}
+ * Permission for checking that a user should have access to the given {@link MetadataTemplateField}s in a
+ * {@link ProjectMetadataResponse}.  This will check the user's role on the project and whether they're in a group.
  */
 @Component
 public class ReadProjectMetadataResponsePermission implements BasePermission<ProjectMetadataResponse> {
@@ -41,7 +42,8 @@ public class ReadProjectMetadataResponsePermission implements BasePermission<Pro
 
 	@Autowired
 	public ReadProjectMetadataResponsePermission(UserRepository userRepository,
-			ProjectUserJoinRepository projectUserJoinRepository, UserGroupProjectJoinRepository userGroupProjectJoinRepository,
+			ProjectUserJoinRepository projectUserJoinRepository,
+			UserGroupProjectJoinRepository userGroupProjectJoinRepository,
 			MetadataRestrictionRepository metadataRestrictionRepository) {
 		this.userRepository = userRepository;
 		this.projectUserJoinRepository = projectUserJoinRepository;
@@ -67,11 +69,12 @@ public class ReadProjectMetadataResponsePermission implements BasePermission<Pro
 		User user = userRepository.loadUserByUsername(authentication.getName());
 		Project project = metadataResponse.getProject();
 
-		//get the user's role on the project
+		//get the user's role on the project and check if they're in a group
 		ProjectUserJoin projectJoinForUser = projectUserJoinRepository.getProjectJoinForUser(project, user);
 		List<UserGroupProjectJoin> groupsForProjectAndUser = userGroupProjectJoinRepository.findGroupsForProjectAndUser(
 				project, user);
 
+		//find the maxiumum metadata role for the user on the project between the user and group permissions
 		ProjectMetadataRole userProjectRole = ProjectMetadataRole.getMaxRoleForProjectAndGroups(projectJoinForUser,
 				groupsForProjectAndUser);
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadProjectMetadataResponsePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadProjectMetadataResponsePermission.java
@@ -19,7 +19,9 @@ import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataRestri
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.ProjectMetadataResponse;
 import ca.corefacility.bioinformatics.irida.model.user.Role;
 import ca.corefacility.bioinformatics.irida.model.user.User;
+import ca.corefacility.bioinformatics.irida.model.user.group.UserGroupProjectJoin;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectUserJoinRepository;
+import ca.corefacility.bioinformatics.irida.repositories.joins.project.UserGroupProjectJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.MetadataRestrictionRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
 import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
@@ -34,14 +36,16 @@ public class ReadProjectMetadataResponsePermission implements BasePermission<Pro
 
 	private UserRepository userRepository;
 	private ProjectUserJoinRepository projectUserJoinRepository;
+	private UserGroupProjectJoinRepository userGroupProjectJoinRepository;
 	private MetadataRestrictionRepository metadataRestrictionRepository;
 
 	@Autowired
 	public ReadProjectMetadataResponsePermission(UserRepository userRepository,
-			ProjectUserJoinRepository projectUserJoinRepository,
+			ProjectUserJoinRepository projectUserJoinRepository, UserGroupProjectJoinRepository userGroupProjectJoinRepository,
 			MetadataRestrictionRepository metadataRestrictionRepository) {
 		this.userRepository = userRepository;
 		this.projectUserJoinRepository = projectUserJoinRepository;
+		this.userGroupProjectJoinRepository = userGroupProjectJoinRepository;
 		this.metadataRestrictionRepository = metadataRestrictionRepository;
 	}
 
@@ -62,18 +66,23 @@ public class ReadProjectMetadataResponsePermission implements BasePermission<Pro
 		//get the user & project
 		User user = userRepository.loadUserByUsername(authentication.getName());
 		Project project = metadataResponse.getProject();
-		ProjectUserJoin projectJoinForUser = projectUserJoinRepository.getProjectJoinForUser(project, user);
 
 		//get the user's role on the project
-		ProjectMetadataRole userProjectRole;
-		if (projectJoinForUser != null) {
-			userProjectRole = projectJoinForUser.getMetadataRole();
-		} else if (user.getSystemRole()
+		ProjectUserJoin projectJoinForUser = projectUserJoinRepository.getProjectJoinForUser(project, user);
+		List<UserGroupProjectJoin> groupsForProjectAndUser = userGroupProjectJoinRepository.findGroupsForProjectAndUser(
+				project, user);
+
+		ProjectMetadataRole userProjectRole = ProjectMetadataRole.getMaxRoleForProjectAndGroups(projectJoinForUser,
+				groupsForProjectAndUser);
+
+		//if the user isn't on the project but is an admin, treat them as a project owner
+		if (userProjectRole == null && user.getSystemRole()
 				.equals(Role.ROLE_ADMIN)) {
-			//if the user isn't on the project but is an admin, treat them as a project owner
 			userProjectRole = ProjectMetadataRole.LEVEL_4;
-		} else {
-			//if the user is not otherwise on the project, they shouldn't be able to read anything
+		}
+
+		//if the role is _still_ null, then they're not allowed to read
+		if (userProjectRole == null) {
 			return false;
 		}
 
@@ -96,6 +105,8 @@ public class ReadProjectMetadataResponsePermission implements BasePermission<Pro
 		 * for each field check if the set of fields contain any they shouldn't be able to read.
 		 * this will return true if the user is allowed to read all the fields in the set.
 		 */
+
+		final ProjectMetadataRole finalUserProjectRole = userProjectRole; //need a final copy of this role because its being used in the lambda below
 		boolean allFieldsValid = fields.stream()
 				.filter(field -> {
 					//if we have a restriction on a field, compare it against the user's role on the project
@@ -106,7 +117,7 @@ public class ReadProjectMetadataResponsePermission implements BasePermission<Pro
 						/*
 						 * Compare the restriction level to the user's role.  If user's role is less, return the unauthorized field.
 						 */
-						return userProjectRole.getLevel() < restrictionRole.getLevel();
+						return finalUserProjectRole.getLevel() < restrictionRole.getLevel();
 					} else {
 						//if there's no restriction set for the field, all users can view
 						return false;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/ProjectService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/ProjectService.java
@@ -59,7 +59,7 @@ public interface ProjectService extends CRUDService<Long, Project> {
 	 *
 	 * @return a reference to the relationship resource created between the two entities.
 	 */
-	public Join<Project, UserGroup> addUserGroupToProject(Project project, UserGroup userGroup, ProjectRole role);
+	public Join<Project, UserGroup> addUserGroupToProject(Project project, UserGroup userGroup, ProjectRole role, ProjectMetadataRole metadataRole);
 
 	/**
 	 * Remove the specified {@link User} from the {@link Project}.
@@ -117,7 +117,7 @@ public interface ProjectService extends CRUDService<Long, Project> {
 	 *             owner
 	 */
 	public Join<Project, UserGroup> updateUserGroupProjectRole(Project project, UserGroup userGroup,
-			ProjectRole projectRole) throws ProjectWithoutOwnerException;
+			ProjectRole projectRole, ProjectMetadataRole metadataRole) throws ProjectWithoutOwnerException;
 
 	/**
 	 * Add the specified {@link Sample} to the {@link Project}.

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/ProjectService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/ProjectService.java
@@ -38,7 +38,7 @@ public interface ProjectService extends CRUDService<Long, Project> {
 	 *
 	 * @param project      the {@link Project} to add the user to.
 	 * @param user         the user to add to the {@link Project}.
-	 * @param role         the role that the user plays on the {@link Project}.
+	 * @param role         the role that the user has on the {@link Project}.
 	 * @param metadataRole the access level the user has on the metadata in the project
 	 * @return a reference to the relationship resource created between the two entities.
 	 */
@@ -52,11 +52,12 @@ public interface ProjectService extends CRUDService<Long, Project> {
 	 *
 	 * @param project      the {@link Project} to add the user to.
 	 * @param userGroup    the user group to add to the {@link Project}.
-	 * @param role         the role that the user plays on the {@link Project}.
+	 * @param role         the role that the group has on the {@link Project}.
 	 * @param metadataRole the {@link ProjectMetadataRole} to set for the group
 	 * @return a reference to the relationship resource created between the two entities.
 	 */
-	public Join<Project, UserGroup> addUserGroupToProject(Project project, UserGroup userGroup, ProjectRole role, ProjectMetadataRole metadataRole);
+	public Join<Project, UserGroup> addUserGroupToProject(Project project, UserGroup userGroup, ProjectRole role,
+			ProjectMetadataRole metadataRole);
 
 	/**
 	 * Remove the specified {@link User} from the {@link Project}.

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/ProjectService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/ProjectService.java
@@ -44,19 +44,16 @@ public interface ProjectService extends CRUDService<Long, Project> {
 	 */
 	public Join<Project, User> addUserToProject(Project project, User user, ProjectRole role,
 			ProjectMetadataRole metadataRole);
-	
+
 	/**
 	 * Add the specified {@link UserGroup} to the {@link Project} with a {@link Role} . If the {@link UserGroup} is a manager for
 	 * the {@link Project}, then the {@link UserGroup} should be added to the {@link Project} with the 'ROLE_MANAGER' {@link
 	 * Role}.
 	 *
-	 * @param project
-	 * 		the {@link Project} to add the user to.
-	 * @param userGroup
-	 * 		the user group to add to the {@link Project}.
-	 * @param role
-	 * 		the role that the user plays on the {@link Project}.
-	 *
+	 * @param project      the {@link Project} to add the user to.
+	 * @param userGroup    the user group to add to the {@link Project}.
+	 * @param role         the role that the user plays on the {@link Project}.
+	 * @param metadataRole the {@link ProjectMetadataRole} to set for the group
 	 * @return a reference to the relationship resource created between the two entities.
 	 */
 	public Join<Project, UserGroup> addUserGroupToProject(Project project, UserGroup userGroup, ProjectRole role, ProjectMetadataRole metadataRole);
@@ -103,18 +100,13 @@ public interface ProjectService extends CRUDService<Long, Project> {
 	/**
 	 * Update a {@link UserGroup}'s {@link ProjectRole} on a {@link Project}
 	 *
-	 * @param project
-	 *            The project to update
-	 * @param userGroup
-	 *            The user group to update
-	 * @param projectRole
-	 *            The role to set
-	 *
+	 * @param project      The project to update
+	 * @param userGroup    The user group to update
+	 * @param projectRole  The role to set
+	 * @param metadataRole the {@link ProjectMetadataRole} to set for the group
 	 * @return The newly updated role object
-	 *
-	 * @throws ProjectWithoutOwnerException
-	 *             If updating the user group leaves the project without an
-	 *             owner
+	 * @throws ProjectWithoutOwnerException If updating the user group leaves the project without an
+	 *                                      owner
 	 */
 	public Join<Project, UserGroup> updateUserGroupProjectRole(Project project, UserGroup userGroup,
 			ProjectRole projectRole, ProjectMetadataRole metadataRole) throws ProjectWithoutOwnerException;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/ProjectServiceImpl.java
@@ -304,7 +304,7 @@ public class ProjectServiceImpl extends CRUDServiceImpl<Long, Project> implement
 	@LaunchesProjectEvent(UserGroupRoleSetProjectEvent.class)
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#project, 'canManageLocalProjectSettings')")
 	public Join<Project, UserGroup> updateUserGroupProjectRole(Project project, UserGroup userGroup,
-			ProjectRole projectRole) throws ProjectWithoutOwnerException {
+			ProjectRole projectRole, ProjectMetadataRole metadataRole) throws ProjectWithoutOwnerException {
 		final UserGroupProjectJoin j = ugpjRepository.findByProjectAndUserGroup(project, userGroup);
 		if (j == null) {
 			throw new EntityNotFoundException(
@@ -314,6 +314,7 @@ public class ProjectServiceImpl extends CRUDServiceImpl<Long, Project> implement
 			throw new ProjectWithoutOwnerException("This role change would leave the project without an owner");
 		}
 		j.setProjectRole(projectRole);
+		j.setMetadataRole(metadataRole);
 		return ugpjRepository.save(j);
 	}
 
@@ -675,8 +676,8 @@ public class ProjectServiceImpl extends CRUDServiceImpl<Long, Project> implement
 	@Override
 	@LaunchesProjectEvent(UserGroupRoleSetProjectEvent.class)
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#project, 'canManageLocalProjectSettings')")
-	public Join<Project, UserGroup> addUserGroupToProject(final Project project, final UserGroup userGroup, final ProjectRole role) {
-		return ugpjRepository.save(new UserGroupProjectJoin(project, userGroup, role));
+	public Join<Project, UserGroup> addUserGroupToProject(final Project project, final UserGroup userGroup, final ProjectRole role, ProjectMetadataRole metadataRole) {
+		return ugpjRepository.save(new UserGroupProjectJoin(project, userGroup, role, metadataRole));
 	}
 
 	/**

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/MetadataTemplateService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/MetadataTemplateService.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Set;
 
 import ca.corefacility.bioinformatics.irida.model.enums.ProjectMetadataRole;
-import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplate;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
@@ -149,17 +148,6 @@ public interface MetadataTemplateService extends CRUDService<Long, MetadataTempl
 	 * @return a list of {@link MetadataTemplateField}
 	 */
 	public List<MetadataTemplateField> getPermittedFieldsForTemplate(MetadataTemplate template);
-
-	/**
-	 * Get all {@link MetadataTemplateField} that are permitted to be read by a given {@link ProjectRole}
-	 *
-	 * @param project the {@link Project} to get fields for
-	 * @param role    the {@link ProjectMetadataRole} to request
-	 * @param includeTemplateFields whether to include fields from the project's associated {@link MetadataTemplate}s
-	 * @return the {@link MetadataTemplateField} the given role can read
-	 */
-	public List<MetadataTemplateField> getPermittedFieldsForRole(Project project, ProjectMetadataRole role,
-			boolean includeTemplateFields);
 
 	/**
 	 * Get all {@link MetadataTemplateField} that the currently logged in user is allowed to read

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/21.05/metadata-restrictions.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/21.05/metadata-restrictions.xml
@@ -47,5 +47,15 @@
         <addColumn tableName="project_user_AUD">
             <column name="metadataRole" type="varchar(255)" value="LEVEL_4"/>
         </addColumn>
+
+        <addColumn tableName="user_group_project">
+            <column name="metadata_role" type="varchar(255)" value="LEVEL_4">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <addColumn tableName="user_group_project_AUD">
+            <column name="metadata_role" type="varchar(255)" value="LEVEL_4"/>
+        </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/sql/required-data.sql
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/sql/required-data.sql
@@ -263,7 +263,7 @@ INSERT INTO project (`createdDate`, `modifiedDate`, `name`) VALUES (DATE_SUB(NOW
 INSERT INTO project (`createdDate`, `modifiedDate`, `name`) VALUES (DATE_SUB(NOW(), INTERVAL 9 YEAR), DATE_SUB(NOW(), INTERVAL 9 YEAR), 'Project 186');
 INSERT INTO project (`createdDate`, `modifiedDate`, `name`) VALUES (DATE_SUB(NOW(), INTERVAL 10 YEAR), DATE_SUB(NOW(), INTERVAL 10 YEAR), 'Project 187');
 
-INSERT INTO user_group_project(`created_date`, `project_role`, `project_id`, `user_group_id`) values (now(), 'PROJECT_USER', 50, 8);
+INSERT INTO user_group_project(`created_date`, `project_role`, `metadata_role`, `project_id`, `user_group_id`) values (now(), 'PROJECT_USER', 'LEVEL_1', 50, 8);
 
 -- relationship between projects and users
 INSERT INTO project_user (`createdDate`, `project_id`, `user_id`, `projectRole`, `email_subscription`, `metadataRole`) VALUES (now(), 1, 2, 'PROJECT_OWNER', 0, 'LEVEL_4');

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIActivitiesServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIActivitiesServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import ca.corefacility.bioinformatics.irida.model.enums.ProjectMetadataRole;
 import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.model.event.*;
 import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectSampleJoin;
@@ -78,7 +79,7 @@ public class UIActivitiesServiceTest {
 
 		UserGroup userGroup = new UserGroup("MY GROUP");
 		UserGroupProjectJoin userGroupProjectJoin = new UserGroupProjectJoin(project, userGroup,
-				ProjectRole.PROJECT_USER);
+				ProjectRole.PROJECT_USER, ProjectMetadataRole.LEVEL_1);
 		UserGroupRoleSetProjectEvent userGroupRoleSetProjectEvent = new UserGroupRoleSetProjectEvent(
 				userGroupProjectJoin);
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectUserGroupServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectUserGroupServiceTest.java
@@ -42,9 +42,9 @@ public class UIProjectUserGroupServiceTest {
 	private final UserGroup USER_GROUP_2 = new UserGroup("G2");
 	private final UserGroup USER_GROUP_3 = new UserGroup("G3");
 	private final List<UserGroupProjectJoin> PROJECT_USER_GROUP_JOINS = ImmutableList.of(
-			new UserGroupProjectJoin(PROJECT, USER_GROUP_1, ProjectRole.PROJECT_USER),
-			new UserGroupProjectJoin(PROJECT, USER_GROUP_2, ProjectRole.PROJECT_USER),
-			new UserGroupProjectJoin(PROJECT, USER_GROUP_3, ProjectRole.PROJECT_OWNER));
+			new UserGroupProjectJoin(PROJECT, USER_GROUP_1, ProjectRole.PROJECT_USER, ProjectMetadataRole.LEVEL_1),
+			new UserGroupProjectJoin(PROJECT, USER_GROUP_2, ProjectRole.PROJECT_USER, ProjectMetadataRole.LEVEL_1),
+			new UserGroupProjectJoin(PROJECT, USER_GROUP_3, ProjectRole.PROJECT_OWNER, ProjectMetadataRole.LEVEL_4));
 	private final List<UserGroup> USER_GROUPS = ImmutableList.of(USER_GROUP_1, USER_GROUP_2, USER_GROUP_3);
 	private final Locale LOCALE = Locale.CANADA;
 	private UIProjectUserGroupsService service;
@@ -100,15 +100,16 @@ public class UIProjectUserGroupServiceTest {
 		service.addUserGroupToProject(1L, newMemberRequest, LOCALE);
 		verify(projectService, times(1)).read(1L);
 		verify(userGroupService, times(1)).read(1L);
-		verify(projectService, times(1)).addUserGroupToProject(PROJECT, USER_GROUP_1, ProjectRole.PROJECT_OWNER);
+		verify(projectService, times(1)).addUserGroupToProject(PROJECT, USER_GROUP_1, ProjectRole.PROJECT_OWNER,
+				ProjectMetadataRole.LEVEL_4);
 	}
 
 	@Test
 	public void testUpdateUserGroupProjectRole() throws ProjectWithoutOwnerException {
-		service.updateUserGroupRoleOnProject(1L, 1L, ProjectRole.PROJECT_USER.toString(), LOCALE);
+		service.updateUserGroupRoleOnProject(1L, 1L, ProjectRole.PROJECT_USER.toString(), ProjectMetadataRole.LEVEL_1.toString(), LOCALE);
 		verify(projectService, times(1)).read(1L);
 		verify(userGroupService, times(1)).read(1L);
-		verify(projectService, times(1)).updateUserGroupProjectRole(PROJECT, USER_GROUP_1, ProjectRole.PROJECT_USER);
+		verify(projectService, times(1)).updateUserGroupProjectRole(PROJECT, USER_GROUP_1, ProjectRole.PROJECT_USER, ProjectMetadataRole.LEVEL_1);
 	}
 
 	private Page<UserGroupProjectJoin> getPagedUserGroupsForProject() {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadMetadataEntryPermissionTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadMetadataEntryPermissionTest.java
@@ -20,6 +20,7 @@ import ca.corefacility.bioinformatics.irida.model.user.Role;
 import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectSampleJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectUserJoinRepository;
+import ca.corefacility.bioinformatics.irida.repositories.joins.project.UserGroupProjectJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.MetadataEntryRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.MetadataRestrictionRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
@@ -45,6 +46,8 @@ public class ReadMetadataEntryPermissionTest {
 	ProjectSampleJoinRepository projectSampleJoinRepository;
 	@Mock
 	MetadataEntryRepository metadataEntryRepository;
+	@Mock
+	UserGroupProjectJoinRepository userGroupProjectJoinRepository;
 
 	Project project;
 	User user;
@@ -60,7 +63,7 @@ public class ReadMetadataEntryPermissionTest {
 		MockitoAnnotations.initMocks(this);
 
 		permission = new ReadMetadataEntryPermission(metadataEntryRepository, projectSampleJoinRepository,
-				metadataRestrictionRepository, projectUserJoinRepository, userRepository);
+				metadataRestrictionRepository, projectUserJoinRepository, userRepository, userGroupProjectJoinRepository);
 
 		user = new User();
 		user.setUsername("user");

--- a/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadProjectMetadataResponsePermissionTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadProjectMetadataResponsePermissionTest.java
@@ -22,6 +22,7 @@ import ca.corefacility.bioinformatics.irida.model.sample.metadata.ProjectMetadat
 import ca.corefacility.bioinformatics.irida.model.user.Role;
 import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectUserJoinRepository;
+import ca.corefacility.bioinformatics.irida.repositories.joins.project.UserGroupProjectJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.MetadataRestrictionRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
 
@@ -41,6 +42,8 @@ public class ReadProjectMetadataResponsePermissionTest {
 	@Mock
 	ProjectUserJoinRepository projectUserJoinRepository;
 	@Mock
+	UserGroupProjectJoinRepository userGroupProjectJoinRepository;
+	@Mock
 	MetadataRestrictionRepository metadataRestrictionRepository;
 
 	User user;
@@ -52,7 +55,7 @@ public class ReadProjectMetadataResponsePermissionTest {
 		MockitoAnnotations.initMocks(this);
 
 		permission = new ReadProjectMetadataResponsePermission(userRepository, projectUserJoinRepository,
-				metadataRestrictionRepository);
+				userGroupProjectJoinRepository, metadataRestrictionRepository);
 
 		admin = new User();
 		admin.setUsername("admin");

--- a/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ReadProjectPermissionTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ReadProjectPermissionTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
+import ca.corefacility.bioinformatics.irida.model.enums.ProjectMetadataRole;
 import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.model.joins.Join;
 import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectUserJoin;
@@ -130,7 +131,7 @@ public class ReadProjectPermissionTest {
 		final Project p = new Project();
 		final UserGroup g = new UserGroup("The group");
 		final List<UserGroupProjectJoin> projectGroups = new ArrayList<>();
-		projectGroups.add(new UserGroupProjectJoin(p, g, ProjectRole.PROJECT_USER));
+		projectGroups.add(new UserGroupProjectJoin(p, g, ProjectRole.PROJECT_USER, ProjectMetadataRole.LEVEL_1));
 
 		when(userRepository.loadUserByUsername(username)).thenReturn(u);
 		when(projectRepository.findById(1L)).thenReturn(Optional.of(p));

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/ProjectServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/ProjectServiceImplIT.java
@@ -101,7 +101,7 @@ public class ProjectServiceImplIT {
 	public void testUpdateUserGroupRoleOnProject() throws ProjectWithoutOwnerException {
 		final UserGroup userGroup = userGroupService.read(1L);
 		final Project project = projectService.read(9L);
-		projectService.updateUserGroupProjectRole(project, userGroup, ProjectRole.PROJECT_USER);
+		projectService.updateUserGroupProjectRole(project, userGroup, ProjectRole.PROJECT_USER, ProjectMetadataRole.LEVEL_1);
 	}
 
 	@Test(expected = ProjectWithoutOwnerException.class)

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/ProjectServiceImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/ProjectServiceImplTest.java
@@ -460,7 +460,8 @@ public class ProjectServiceImplTest {
 		final UserGroup ug = new UserGroup("group");
 
 		final ProjectUserJoin puj = new ProjectUserJoin(p1, u, ProjectRole.PROJECT_OWNER);
-		final UserGroupProjectJoin ugpj = new UserGroupProjectJoin(p2, ug, ProjectRole.PROJECT_OWNER);
+		final UserGroupProjectJoin ugpj = new UserGroupProjectJoin(p2, ug, ProjectRole.PROJECT_OWNER,
+				ProjectMetadataRole.LEVEL_4);
 
 		when(pujRepository.getProjectsForUser(u)).thenReturn(ImmutableList.of(puj));
 		when(ugpjRepository.findProjectsByUser(u)).thenReturn(ImmutableList.of(ugpj));

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/GroupsPageIT.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/GroupsPageIT.xml
@@ -35,8 +35,8 @@
     <project id="7" organism="E. coli O157:H7"  createdDate="2013-07-18 14:21:19.0" name="project EFGH" modifiedDate="2013-07-18 14:17:19.0" />
     <project id="8" organism="E. coli K-12"  createdDate="2013-07-18 14:21:19.0" name="project IJKL" modifiedDate="2013-07-18 14:17:19.0"  />
 
-    <user_group_project id="1" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" project_id="1" user_group_id="1" />
-    <user_group_project id="2" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" project_id="2" user_group_id="1" />
-    <user_group_project id="3" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" project_id="3" user_group_id="1" />
-    <user_group_project id="4" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" project_id="4" user_group_id="1" />
+    <user_group_project id="1" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" metadata_role="LEVEL_4" project_id="1" user_group_id="1" />
+    <user_group_project id="2" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" metadata_role="LEVEL_4" project_id="2" user_group_id="1" />
+    <user_group_project id="3" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" metadata_role="LEVEL_4" project_id="3" user_group_id="1" />
+    <user_group_project id="4" created_date="2013-07-12 14:20:19.0" project_role="PROJECT_OWNER" metadata_role="LEVEL_4" project_id="4" user_group_id="1" />
 </dataset>

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/service/impl/ProjectServiceImplIT.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/service/impl/ProjectServiceImplIT.xml
@@ -62,8 +62,8 @@
 	<project id="9" createdDate="2013-07-18 14:20:19.0" name="project9" organism="e. coli"  />
 	<project id="10" createdDate="2013-07-18 14:22:19.0" name="listeria" organism="" />
 
-	<user_group_project id="1" created_date="2013-07-18 14:20:19.0" project_role="PROJECT_OWNER" project_id="9" user_group_id="1" />
-	<user_group_project id="2" created_date="2013-07-18 14:20:19.0" project_role="PROJECT_USER" project_id="8" user_group_id="1" />
+	<user_group_project id="1" created_date="2013-07-18 14:20:19.0" project_role="PROJECT_OWNER" metadata_role="LEVEL_4" project_id="9" user_group_id="1" />
+	<user_group_project id="2" created_date="2013-07-18 14:20:19.0" project_role="PROJECT_USER" metadata_role="LEVEL_1" project_id="8" user_group_id="1" />
 
 	<sample id="1"  sampleName="sample"
 			createdDate="2013-07-18 14:20:19.0" />


### PR DESCRIPTION
## Description of changes
Added `ProjectMetadataRole` field to the `UserGroupProjectJoin` so that metadata roles can be set for a user group along with individual users.  This added parameters to a number of places, and will still need updates to the UI to reflect these changes.

The only failing tests should be for updating a user group (as described above) and updating a user's metadata role.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
