### PR TITLE
Displaying ProjectMetadataRole values in metadata restriction page

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIMetadataService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIMetadataService.java
@@ -143,9 +143,9 @@ public class UIMetadataService {
 	 * @return List of metadata fields restrictions
 	 */
 	public List<SelectOption> getMetadataFieldRestrictions(Locale locale) {
-		return Arrays.stream(ProjectRole.values())
+		return Arrays.stream(ProjectMetadataRole.values())
 				.map(role -> new SelectOption(role.toString(),
-						messageSource.getMessage("projectRole." + role, new Object[] {}, locale)))
+						messageSource.getMessage("metadataRole." + role, new Object[] {}, locale)))
 				.collect(Collectors.toList());
 	}
 
@@ -163,7 +163,7 @@ public class UIMetadataService {
 		MetadataTemplateField field = templateService.readMetadataField(fieldId);
 		templateService.setMetadataRestriction(project, field, newRole);
 		return messageSource.getMessage("server.MetadataFieldsListManager.update", new Object[] { field.getLabel(),
-				messageSource.getMessage("projectRole." + newRole.toString(), new Object[] {}, locale) }, locale);
+				messageSource.getMessage("metadataRole." + newRole.toString(), new Object[] {}, locale) }, locale);
 	}
 
 	/**
@@ -219,7 +219,7 @@ public class UIMetadataService {
 	}
 
 	/**
-	 * Utility function to update a specific {@link MetadataTemplateField} with its security restcitions for a project.
+	 * Utility function to update a specific {@link MetadataTemplateField} with its security restrictions for a project.
 	 *
 	 * @param project The {@link Project} the fields belong to
 	 * @param field   the {@link MetadataTemplateField} to update
@@ -227,8 +227,9 @@ public class UIMetadataService {
 	 */
 	private ProjectMetadataField createProjectMetadataField(Project project, MetadataTemplateField field) {
 		MetadataRestriction restriction = templateService.getMetadataRestrictionForFieldAndProject(project, field);
+		//default to LEVEL_1 if no restriction is set
 		String level = restriction == null ?
-				"PROJECT_USER" :
+				ProjectMetadataRole.LEVEL_1.toString() :
 				restriction.getLevel()
 						.toString();
 		return new ProjectMetadataField(field, level);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIMetadataService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIMetadataService.java
@@ -12,7 +12,6 @@ import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
 import ca.corefacility.bioinformatics.irida.model.enums.ProjectMetadataRole;
-import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplate;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectMetadataPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectMetadataPage.java
@@ -204,12 +204,12 @@ public class ProjectMetadataPage extends AbstractPage {
 		return fieldRestrictionSelects.get(row).findElement(By.className("ant-select-selection-item")).getText();
 	}
 
-	public void updateFieldRestrictionToOwner(int row) {
+	public void updateFieldRestrictionToLevel(int row, int optionNumber) {
 		WebDriverWait wait = new WebDriverWait(driver, 2);
 		fieldRestrictionSelects.get(row).click();
 		WebElement dropdown = wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("ant-select-dropdown")));
 		List<WebElement> options = dropdown.findElements(By.className("ant-select-item-option"));
-		options.get(1).click();
+		options.get(optionNumber).click();
 		wait.until(ExpectedConditions.invisibilityOf(dropdown));
 
 	}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectMetadataIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectMetadataIT.java
@@ -22,10 +22,12 @@ public class ProjectMetadataIT extends AbstractIridaUIITChromeDriver {
 				page.getNumberOfMetadataFields());
 
 		// TEST FIELD RESTRICTIONS
-		Assert.assertTrue("Fields restrictions settings should be visible to managers", page.areFieldRestrictionSettingsVisible());
-		Assert.assertEquals("Should currently be set to collaborator by default", "Collaborator", page.getFieldRestrictionForRow(0));
-		page.updateFieldRestrictionToOwner(0);
-		Assert.assertEquals("Field should now be restricted to managers", "Manager", page.getFieldRestrictionForRow(0));
+		Assert.assertTrue("Fields restrictions settings should be visible to managers",
+				page.areFieldRestrictionSettingsVisible());
+		Assert.assertEquals("Should currently be set to level 1 by default", "Level 1",
+				page.getFieldRestrictionForRow(0));
+		page.updateFieldRestrictionToLevel(0, 3);
+		Assert.assertEquals("Field should now be restricted to level 4", "Level 4", page.getFieldRestrictionForRow(0));
 
 		// TEMPLATES
 		page.gotoMetadataTemplates();


### PR DESCRIPTION
## Description of changes
Changed the options for metadata restrictions in the project-settings-metadata page to show the list of available ProjectMetadataRole to set.

![after-metadata-role](https://user-images.githubusercontent.com/8951708/140181865-5dfe0069-6040-42b7-8ccb-1812c295f8cc.png)

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
