### PR TITLE
Fixes issue where metadata role displaying only UNKOWN on project members table

### DIFF
--- a/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
+++ b/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
@@ -29,7 +29,7 @@ export function ProjectMembersTable({ projectId }) {
   const { data: project = {} } = useGetProjectDetailsQuery(projectId);
   const { identifier: userId } = useSelector((state) => state.user);
   const { roles: projectRoles, getRoleFromKey } = useProjectRoles();
-  const { roles: metadataRoles } = useMetadataRoles();
+  const { roles: metadataRoles, getRoleFromKey: getMetadataRoleFromKey } = useMetadataRoles();
 
   React.useEffect(() => {
     dispatch(getCurrentUserDetails());
@@ -86,7 +86,7 @@ export function ProjectMembersTable({ projectId }) {
             currentRole={item.metadataRole}
           />
         ) : (
-          getRoleFromKey(item.metadataRole)
+          getMetadataRoleFromKey(item.metadataRole)
         );
       },
     },


### PR DESCRIPTION
## Description of changes
The problem was that when trying to lookup the proper translation for the level it was trying to get it from the project levels not the metadata levels.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:
